### PR TITLE
Interface target agnostic patch

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ async def init(discord_band: DiscordBand, windows: Windows):
 
 discord_band = None
 try:
-    print("Starting VRC Discord Notifications...")
+    print("Starting OSC Discord Notifications...")
     port = config.get_port_number()
     discord_band = DiscordBand(port)
     windows = Windows()


### PR DESCRIPTION
this its to update some of the interface output to be more target receptor agnostic 
(ie. the app will work fine sending OSC data to both VRC and CVR, so no need to reference either in output)